### PR TITLE
Replace Python test with C-based RTL-SDR utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.RECIPEPREFIX = >
+CC = gcc
+CFLAGS = -Wall -O2
+LIBS = -lrtlsdr
+
+TARGET = check_rtl
+SRC = $(TARGET).c
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+>$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+
+clean:
+>rm -f $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # sdr
+
+A minimal utility to verify communication with a USB-connected RTL-SDR dongle.
+
+## Setup
+
+Install build dependencies (Ubuntu):
+
+```bash
+sudo apt-get update
+sudo apt-get install -y librtlsdr-dev build-essential
+```
+
+## Build
+
+Compile the program using the provided Makefile:
+
+```bash
+make
+```
+
+## Usage
+
+Ensure the RTL-SDR is plugged into the system, then run:
+
+```bash
+./check_rtl 100000000
+```
+
+The frequency argument is specified in Hz and defaults to 100000000 (100 MHz).
+If successful, the program will open the device and tune it to the specified
+frequency.

--- a/check_rtl.c
+++ b/check_rtl.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <rtl-sdr.h>
+
+int main(int argc, char **argv) {
+    uint32_t freq = 100000000; // default 100 MHz
+    if (argc > 1) {
+        freq = (uint32_t)strtoul(argv[1], NULL, 10);
+    }
+
+    int device_count = rtlsdr_get_device_count();
+    if (device_count < 1) {
+        fprintf(stderr, "No RTL-SDR devices found.\n");
+        return 1;
+    }
+
+    rtlsdr_dev_t *dev = NULL;
+    int r = rtlsdr_open(&dev, 0);
+    if (r != 0) {
+        fprintf(stderr, "Failed to open RTL-SDR device: %d\n", r);
+        return 1;
+    }
+
+    r = rtlsdr_set_center_freq(dev, freq);
+    if (r != 0) {
+        fprintf(stderr, "Failed to set center frequency: %d\n", r);
+    } else {
+        printf("Tuned to %u Hz\n", freq);
+    }
+
+    rtlsdr_close(dev);
+    printf("Device closed.\n");
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- replace Python connectivity test with C program `check_rtl.c`
- add `Makefile` for building the utility on Ubuntu
- document build prerequisites and usage in `README`

## Testing
- `apt-get install -y librtlsdr-dev build-essential`
- `make`
- `./check_rtl 100000000` *(fails: No RTL-SDR devices found.)*

------
https://chatgpt.com/codex/tasks/task_e_68a77490296c8326826ac8e8b5e06eee