### PR TITLE
Add configure script and build guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.mk
+check_rtl

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .RECIPEPREFIX = >
-CC = gcc
-CFLAGS = -Wall -O2
-LIBS = -lrtlsdr
+-include config.mk
+
+CC ?= gcc
+CFLAGS ?= -Wall -O2
+LIBS ?= -lrtlsdr
 
 TARGET = check_rtl
 SRC = $(TARGET).c

--- a/README.md
+++ b/README.md
@@ -8,12 +8,23 @@ Install build dependencies (Ubuntu):
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y librtlsdr-dev build-essential
+sudo apt-get install -y librtlsdr-dev build-essential pkg-config
 ```
 
 ## Build
 
-Compile the program using the provided Makefile:
+First, run the configuration script to verify dependencies and generate build
+settings:
+
+```bash
+./configure
+```
+
+This will create a `config.mk` file with the appropriate compiler and linker
+flags. You can choose a different compiler by setting `CC` when invoking the
+script, e.g. `CC=clang ./configure`.
+
+Compile the program using the generated settings:
 
 ```bash
 make

--- a/configure
+++ b/configure
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+# Simple configure script for check_rtl
+
+CC=${CC:-gcc}
+
+if ! command -v "$CC" >/dev/null 2>&1; then
+  echo "Error: C compiler '$CC' not found." >&2
+  exit 1
+fi
+
+if ! command -v pkg-config >/dev/null 2>&1; then
+  echo "Error: pkg-config not found. Please install it." >&2
+  exit 1
+fi
+
+if ! pkg-config --exists librtlsdr; then
+  echo "Error: librtlsdr development files not found." >&2
+  exit 1
+fi
+
+PKG_CFLAGS=$(pkg-config --cflags librtlsdr)
+PKG_LIBS=$(pkg-config --libs librtlsdr)
+
+cat > config.mk <<CONFIG
+CC = $CC
+CFLAGS = -Wall -O2 $PKG_CFLAGS
+LIBS = $PKG_LIBS
+CONFIG
+
+echo "Configuration complete. Run 'make' to build."


### PR DESCRIPTION
## Summary
- Add `configure` script to detect build dependencies and generate `config.mk`
- Integrate optional config file into `Makefile` and allow overriding build variables
- Document configuration step and custom compiler support in README

## Testing
- `./configure` *(fails: librtlsdr development files not found)*
- `make` *(fails: rtl-sdr.h missing)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_68a77913d6908326b2dbafa69b19907b